### PR TITLE
couponErrorKey value is being provided as part of  result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `errorKey` value now is being provided as part of `insertCoupon` result.
+
 ## [0.6.0] - 2019-11-08
 
 ### Removed

--- a/react/OrderCoupon.tsx
+++ b/react/OrderCoupon.tsx
@@ -69,7 +69,7 @@ export const OrderCouponProvider = compose(
           success: !!(
             newOrderForm.marketingData && newOrderForm.marketingData.coupon
           ),
-          errorKey: errorKey,
+          errorKey,
         }
       } catch (error) {
         if (!error || error.code !== TASK_CANCELLED) {


### PR DESCRIPTION
#### What problem is this solving?

Since `couponErrorKey` value was being kept both on `order-coupon` and `checkout-coupon`, it was causing some inconsistency problems. This PR fix it by moving `couponErrorKey` value to be a part of `insertCoupon` result.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://fixcouponerror--checkoutio.myvtex.com/cart)
- Try to insert a coupon
- Verify if its working normally

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️| Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

